### PR TITLE
Suggested fix to make exporter work

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -3,9 +3,10 @@
           %%,{logger_level,debug}
           ]},
    {opentelemetry,
-  [{processors, 
+  [{processors,
     [{otel_batch_processor,
-        #{exporter => {opentelemetry_exporter, #{protocol => http,
-                                                 endpoints => ["http://localhost:4317"],
-                                                 headers => [{"x-honeycomb-dataset", "experiments"}]}}}}]}]}
+        #{exporter => {opentelemetry_exporter, #{
+                                                 endpoints =>
+                                                 [{http, "localhost", 55681, []}]
+                                                 }}}}]}]}
 ].

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,18 @@
-version: "2"
+version: '3'
 services:
+  otel:
+    image: otel/opentelemetry-collector-contrib-dev:latest
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    ports:
+      - '55681:55681'
+      - '55680:55680'
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
+
+  zipkin:
+    image: openzipkin/zipkin-slim
+    ports:
+      - '9411:9411'
 
   # Jaeger
   jaeger-all-in-one:
@@ -9,54 +22,5 @@ services:
       - "14268"
       - "14250"
 
-  # Zipkin
-  zipkin-all-in-one:
-    image: openzipkin/zipkin:latest
-    ports:
-      - "9411:9411"
 
-  # Collector
-  otel-collector:
-    image: ${OTELCOL_IMG}
-    command: ["--config=/etc/otel-collector-config.yaml", "${OTELCOL_ARGS}"]
-    volumes:
-      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
-    ports:
-      - "1888:1888"   # pprof extension
-      - "8888:8888"   # Prometheus metrics exposed by the collector
-      - "8889:8889"   # Prometheus exporter metrics
-      - "13133:13133" # health_check extension
-      - "4317:4137"        # OTLP gRPC receiver
-      - "55670:55679" # zpages extension
-    depends_on:
-      - jaeger-all-in-one
-      - zipkin-all-in-one
 
-  # demo-client:
-  #   build:
-  #     dockerfile: Dockerfile
-  #     context: ./client
-  #   environment:
-  #     - OTEL_EXPORTER_OTLP_ENDPOINT=otel-collector:4317
-  #     - DEMO_SERVER_ENDPOINT=http://demo-server:7080/hello
-  #   depends_on:
-  #     - demo-server
-
-  # demo-server:
-  #   build:
-  #     dockerfile: Dockerfile
-  #     context: ./server
-  #   environment:
-  #     - OTEL_EXPORTER_OTLP_ENDPOINT=otel-collector:4317
-  #   ports:
-  #     - "7080"
-  #   depends_on:
-  #     - otel-collector
-
-  prometheus:
-    container_name: prometheus
-    image: prom/prometheus:latest
-    volumes:
-      - ./prometheus.yaml:/etc/prometheus/prometheus.yml
-    ports:
-      - "9090:9090"

--- a/otel-collector-config.yaml
+++ b/otel-collector-config.yaml
@@ -2,41 +2,28 @@ receivers:
   otlp:
     protocols:
       grpc:
-
+        endpoint: "0.0.0.0:55680"
+      http:
+        endpoint: "0.0.0.0:55681"
+processors:
+  batch:
+    send_batch_size: 1024
+    timeout: 5s
 exporters:
-  prometheus:
-    endpoint: "0.0.0.0:8889"
-    const_labels:
-      label1: value1
-  logging:
-
   zipkin:
-    endpoint: "http://zipkin-all-in-one:9411/api/v2/spans"
-    format: proto
-
+    endpoint: "http://zipkin:9411/api/v2/spans"
   jaeger:
     endpoint: jaeger-all-in-one:14250
     tls:
       insecure: true
-
-processors:
-  batch:
-
 extensions:
-  health_check:
-  pprof:
-    endpoint: :1888
-  zpages:
-    endpoint: :55679
-
+  zpages: {}
 service:
-  extensions: [pprof, zpages, health_check]
+  extensions: [zpages]
   pipelines:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, zipkin, jaeger]
-    metrics:
-      receivers: [otlp]
-      processors: [batch]
-      exporters: [logging, prometheus]
+      exporters: [zipkin, jaeger]
+
+


### PR DESCRIPTION
This is following the examples in: https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/examples/basic_elixir

The reason we are exporting to port `55681` because that's how we configure our otel port to listen to `http_protobuf` protocol in our `otel-collector-config.yaml`

